### PR TITLE
Use Google Flexbox library from Maven Central

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,9 +3,7 @@
 buildscript {
     repositories {
         google()
-        jcenter()
         mavenCentral()
-        maven { url 'https://jitpack.io' }
         maven { url 'https://developer.huawei.com/repo/' }
     }
     dependencies {
@@ -30,7 +28,6 @@ plugins {
 allprojects {
     repositories {
         google()
-        jcenter()
         mavenCentral()
         maven {
             url 'https://jitpack.io'

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -91,7 +91,7 @@ ext {
             //ui
             lottie                                   : 'com.airbnb.android:lottie:6.2.0',
             lottie_compose                           : 'com.airbnb.android:lottie-compose:6.1.0',
-            flexbox                                  : 'com.google.android:flexbox:2.0.1',
+            flexbox                                  : 'com.google.android.flexbox:flexbox:3.0.0',
             shortcut_badger                          : "me.leolin:ShortcutBadger:1.1.22@aar",
             better_link_movement_method              : 'me.saket:better-link-movement-method:2.2.0',
             browser                                  : "androidx.browser:browser:1.3.0",


### PR DESCRIPTION
According to the [Flexbox 3.0.0 release notes](https://github.com/google/flexbox-layout/releases/tag/3.0.0) the only breaking change it that artefact is moved to the Google Maven repository and is published with the new groupId `com.google.android.flexbox`.

So we can safely drop deprecated JCenter repository from the dependencies.

Also I removed JCenter and JitPack from the  buildscript dependencies as they are not used at all.

Besides that, less third-party repositories means smaller surface for supply chain attack.

:ukraine: