### PR TITLE
feat: enable and configure typesafe project accessors

### DIFF
--- a/address_search/build.gradle
+++ b/address_search/build.gradle
@@ -92,9 +92,9 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar', '*.aar'])
-    implementation project(':core')
-    implementation project(':ui_base')
-    implementation project(':search')
+    implementation projects.core
+    implementation projects.uiBase
+    implementation projects.search
     implementation deps.fragment_ktx
     implementation deps.appcompat
     implementation deps.constraint_layout

--- a/analytics/build.gradle
+++ b/analytics/build.gradle
@@ -81,7 +81,7 @@ android {
 }
 
 dependencies {
-    implementation project(':core')
+    implementation projects.core
 
     implementation deps.hilt_android
     kapt deps.hilt_android_compiler

--- a/bankid/build.gradle
+++ b/bankid/build.gradle
@@ -91,9 +91,9 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar', '*.aar'])
-    implementation project(':core')
-    implementation project(':verification')
-    implementation project(':ui_base')
+    implementation projects.core
+    implementation projects.verification
+    implementation projects.uiBase
     implementation deps.fragment_ktx
     implementation deps.appcompat
     implementation deps.constraint_layout

--- a/biometric/build.gradle
+++ b/biometric/build.gradle
@@ -87,9 +87,9 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar', '*.aar'])
-    implementation project(':core')
-    implementation project(':ui_base')
-    implementation project(':diia_storage')
+    implementation projects.core
+    implementation projects.uiBase
+    implementation projects.diiaStorage
     implementation deps.fragment_ktx
     implementation deps.appcompat
     implementation deps.material

--- a/diia_storage/build.gradle
+++ b/diia_storage/build.gradle
@@ -86,7 +86,7 @@ android {
 dependencies {
     implementation deps.security_crypto
 
-    implementation project(':core')
+    implementation projects.core
     implementation deps.moshi
 
     implementation deps.hilt_android

--- a/doc_driver_license/build.gradle
+++ b/doc_driver_license/build.gradle
@@ -94,9 +94,9 @@ dependencies {
     implementation deps.activity_ktx
     implementation deps.fragment_ktx
     implementation deps.appcompat
-    implementation project(path: ':ui_base')
-    implementation project(path: ':core')
-    implementation project(path: ':documents')
+    implementation projects.uiBase
+    implementation projects.core
+    implementation projects.documents
     // Moshi
     implementation deps.moshi
     implementation deps.moshi_adapters

--- a/documents/build.gradle
+++ b/documents/build.gradle
@@ -88,10 +88,10 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar', '*.aar'])
-    implementation project(':core')
-    implementation project(':diia_storage')
-    implementation project(':web')
-    implementation project(path: ':ui_base')
+    implementation projects.core
+    implementation projects.diiaStorage
+    implementation projects.web
+    implementation projects.uiBase
     implementation deps.activity_ktx
     implementation deps.fragment_ktx
     implementation deps.appcompat

--- a/home/build.gradle
+++ b/home/build.gradle
@@ -90,8 +90,8 @@ android {
 
 dependencies {
 
-    implementation project(':core')
-    implementation project(':diia_storage')
+    implementation projects.core
+    implementation projects.diiaStorage
     implementation deps.activity_ktx
     implementation deps.fragment_ktx
     implementation deps.appcompat

--- a/login/build.gradle
+++ b/login/build.gradle
@@ -87,12 +87,12 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar', '*.aar'])
-    implementation project(':core')
-    implementation project(':web')
-    implementation project(':pin')
-    implementation project(':verification')
-    implementation project(':ui_base')
-    implementation project(':diia_storage')
+    implementation projects.core
+    implementation projects.web
+    implementation projects.pin
+    implementation projects.verification
+    implementation projects.uiBase
+    implementation projects.diiaStorage
     implementation deps.fragment_ktx
     implementation deps.appcompat
     implementation deps.material

--- a/menu/build.gradle
+++ b/menu/build.gradle
@@ -89,10 +89,10 @@ android {
 
 dependencies {
 
-    implementation project(path: ':ui_base')
-    implementation project(':core')
-    implementation project(':diia_storage')
-    implementation project(path: ':web')
+    implementation projects.uiBase
+    implementation projects.core
+    implementation projects.diiaStorage
+    implementation projects.web
 
     implementation deps.fragment_ktx
     implementation deps.appcompat

--- a/notifications/build.gradle
+++ b/notifications/build.gradle
@@ -89,8 +89,8 @@ android {
 
 dependencies {
 
-    implementation project(':core')
-    implementation project(':analytics')
+    implementation projects.core
+    implementation projects.analytics
 
     implementation project(':diia_storage')
     implementation deps.activity_ktx

--- a/opensource/build.gradle
+++ b/opensource/build.gradle
@@ -137,25 +137,25 @@ android {
 }
 
 dependencies {
-    implementation project(':core')
-    implementation project(':splash')
-    implementation project(':home')
-    implementation project(':menu')
-    implementation project(':web')
-    implementation project(':verification')
-    implementation project(':bankid')
-    implementation project(':login')
-    implementation project(':publicservice')
-    implementation project(':ps_criminal_cert')
-    implementation project(':pin')
-    implementation project(':biometric')
-    implementation project(':notifications')
-    implementation project(':analytics')
-    implementation project(':search')
-    implementation project(':address_search')
-    implementation project(':diia_storage')
-    implementation project(':documents')
-    implementation project(':doc_driver_license')
+    implementation projects.core
+    implementation projects.splash
+    implementation projects.home
+    implementation projects.menu
+    implementation projects.web
+    implementation projects.verification
+    implementation projects.bankid
+    implementation projects.login
+    implementation projects.publicservice
+    implementation projects.psCriminalCert
+    implementation projects.pin
+    implementation projects.biometric
+    implementation projects.notifications
+    implementation projects.analytics
+    implementation projects.search
+    implementation projects.addressSearch
+    implementation projects.diiaStorage
+    implementation projects.documents
+    implementation projects.docDriverLicense
     implementation deps.activity_ktx
     implementation deps.fragment_ktx
     implementation deps.legacy_support

--- a/pin/build.gradle
+++ b/pin/build.gradle
@@ -87,9 +87,9 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar', '*.aar'])
-    implementation project(':core')
-    implementation project(':ui_base')
-    implementation project(':diia_storage')
+    implementation projects.core
+    implementation projects.uiBase
+    implementation projects.diiaStorage
 
     implementation deps.fragment_ktx
     implementation deps.appcompat

--- a/ps_criminal_cert/build.gradle
+++ b/ps_criminal_cert/build.gradle
@@ -93,14 +93,14 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar', '*.aar'])
+    implementation projects.uiBase
+    implementation projects.core
+    implementation projects.publicservice
+    implementation projects.addressSearch
+    implementation projects.search
     implementation deps.activity_ktx
     implementation deps.fragment_ktx
     implementation deps.appcompat
-    implementation project(path: ':ui_base')
-    implementation project(path: ':core')
-    implementation project(path: ':publicservice')
-    implementation project(path: ':address_search')
-    implementation project(path: ':search')
     //lifecycle
     implementation deps.lifecycle_extensions
     implementation deps.lifecycle_livedata_ktx

--- a/publicservice/build.gradle
+++ b/publicservice/build.gradle
@@ -94,12 +94,12 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar', '*.aar'])
+    implementation projects.uiBase
+    implementation projects.core
+    implementation projects.diiaStorage
     implementation deps.activity_ktx
     implementation deps.fragment_ktx
     implementation deps.appcompat
-    implementation project(path: ':ui_base')
-    implementation project(path: ':core')
-    implementation project(path: ':diia_storage')
     //lifecycle
     implementation deps.lifecycle_extensions
     implementation deps.lifecycle_livedata_ktx

--- a/search/build.gradle
+++ b/search/build.gradle
@@ -91,8 +91,8 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar', '*.aar'])
-    implementation project(':core')
-    implementation project(':ui_base')
+    implementation projects.core
+    implementation projects.uiBase
     implementation deps.fragment_ktx
     implementation deps.appcompat
     implementation deps.constraint_layout

--- a/settings.gradle
+++ b/settings.gradle
@@ -21,3 +21,5 @@ include ':analytics'
 include ':diia_storage'
 include ':documents'
 include ':doc_driver_license'
+
+enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")

--- a/splash/build.gradle
+++ b/splash/build.gradle
@@ -90,9 +90,9 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar', '*.aar'])
-    implementation project(':core')
-    implementation project(':ui_base')
-    implementation project(':diia_storage')
+    implementation projects.core
+    implementation projects.uiBase
+    implementation projects.diiaStorage
     implementation deps.fragment_ktx
     implementation deps.appcompat
     implementation deps.constraintlayout

--- a/ui_base/build.gradle
+++ b/ui_base/build.gradle
@@ -104,7 +104,7 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar', '*.aar'])
-    implementation project(':core')
+    implementation projects.core
     implementation deps.activity_compose
     implementation deps.core_ktx
     implementation deps.appcompat

--- a/verification/build.gradle
+++ b/verification/build.gradle
@@ -90,9 +90,9 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar', '*.aar'])
-    implementation project(':core')
-    implementation project(':ui_base')
-    implementation project(':diia_storage')
+    implementation projects.core
+    implementation projects.uiBase
+    implementation projects.diiaStorage
     implementation deps.fragment_ktx
     implementation deps.appcompat
     implementation deps.constraint_layout

--- a/web/build.gradle
+++ b/web/build.gradle
@@ -86,8 +86,8 @@ android {
 
 dependencies {
 
-    implementation project(':core')
-    implementation project(path: ':ui_base')
+    implementation projects.core
+    implementation projects.uiBase
 
     implementation deps.fragment_ktx
     implementation deps.appcompat


### PR DESCRIPTION
This PR introduces first in the series of gradle build file improvements by enabling [type safe project accessors](https://docs.gradle.org/current/userguide/declaring_dependencies.html#sec:type-safe-project-accessors).

Type safe projects accessors is a stable incubating feature.