### PR TITLE
Retrofit api creation with proper extension

### DIFF
--- a/address_search/src/main/java/ua/gov/diia/address_search/di/AddressSearchApiModule.kt
+++ b/address_search/src/main/java/ua/gov/diia/address_search/di/AddressSearchApiModule.kt
@@ -5,6 +5,7 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import retrofit2.Retrofit
+import retrofit2.create
 import ua.gov.diia.address_search.network.ApiAddressSearch
 import ua.gov.diia.core.di.data_source.http.AuthorizedClient
 
@@ -16,5 +17,5 @@ object AddressSearchApiModule {
     @AuthorizedClient
     fun provideApiAddressSearch(
         @AuthorizedClient retrofit: Retrofit
-    ): ApiAddressSearch = retrofit.create(ApiAddressSearch::class.java)
+    ): ApiAddressSearch = retrofit.create()
 }

--- a/bankid/src/main/java/ua/gov/diia/bankid/di/BankIdModule.kt
+++ b/bankid/src/main/java/ua/gov/diia/bankid/di/BankIdModule.kt
@@ -8,6 +8,7 @@ import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoMap
 import dagger.multibindings.StringKey
 import retrofit2.Retrofit
+import retrofit2.create
 import ua.gov.diia.bankid.BankIdConst
 import ua.gov.diia.bankid.network.ApiBankId
 import ua.gov.diia.bankid.ui.VerificationMethodBankId
@@ -28,20 +29,20 @@ interface BankIdModule {
         @UnauthorizedClient
         fun provideApiBankIdUnauthorized(
             @UnauthorizedClient retrofit: Retrofit
-        ): ApiBankId = retrofit.create(ApiBankId::class.java)
+        ): ApiBankId = retrofit.create()
 
 
         @Provides
         @ProlongClient
         fun provideApiBankIdProlong(
             @ProlongClient retrofit: Retrofit
-        ): ApiBankId = retrofit.create(ApiBankId::class.java)
+        ): ApiBankId = retrofit.create()
 
         @Provides
         @AuthorizedClient
         fun provideApiBankIdAuthorized(
             @AuthorizedClient retrofit: Retrofit
-        ): ApiBankId = retrofit.create(ApiBankId::class.java)
+        ): ApiBankId = retrofit.create()
 
         @Provides
         @ProviderVerifiedClient

--- a/login/src/main/java/ua/gov/diia/login/di/LoginModule.kt
+++ b/login/src/main/java/ua/gov/diia/login/di/LoginModule.kt
@@ -6,6 +6,7 @@ import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.Multibinds
 import retrofit2.Retrofit
+import retrofit2.create
 import ua.gov.diia.core.di.data_source.http.UnauthorizedClient
 import ua.gov.diia.login.network.ApiLogin
 import ua.gov.diia.login.ui.PostLoginAction
@@ -24,6 +25,6 @@ interface LoginModule {
         @UnauthorizedClient
         fun provideApiLogin(
             @UnauthorizedClient retrofit: Retrofit
-        ): ApiLogin = retrofit.create(ApiLogin::class.java)
+        ): ApiLogin = retrofit.create()
     }
 }

--- a/notifications/src/main/java/ua/gov/diia/notifications/di/NotificationModule.kt
+++ b/notifications/src/main/java/ua/gov/diia/notifications/di/NotificationModule.kt
@@ -5,6 +5,7 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import retrofit2.Retrofit
+import retrofit2.create
 import ua.gov.diia.core.di.data_source.http.AuthorizedClient
 import ua.gov.diia.core.di.data_source.http.UnauthorizedClient
 import ua.gov.diia.notifications.data.data_source.network.api.notification.ApiNotifications
@@ -17,11 +18,11 @@ object NotificationModule {
     @UnauthorizedClient
     fun provideNotificationApi(
         @UnauthorizedClient retrofit: Retrofit
-    ): ApiNotifications = retrofit.create(ApiNotifications::class.java)
+    ): ApiNotifications = retrofit.create()
 
     @Provides
     @AuthorizedClient
     fun provideApiNotifications(
         @AuthorizedClient retrofit: Retrofit
-    ): ApiNotifications = retrofit.create(ApiNotifications::class.java)
+    ): ApiNotifications = retrofit.create()
 }

--- a/opensource/src/main/java/ua/gov/diia/opensource/di/AppModule.kt
+++ b/opensource/src/main/java/ua/gov/diia/opensource/di/AppModule.kt
@@ -17,6 +17,7 @@ import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import retrofit2.Retrofit
+import retrofit2.create
 import ua.gov.diia.core.controller.PromoController
 import ua.gov.diia.core.data.repository.DataRepository
 import ua.gov.diia.core.data.repository.SystemRepository
@@ -144,7 +145,7 @@ interface AppModule {
         @UnauthorizedClient
         fun provideApiAuth(
             @UnauthorizedClient retrofit: Retrofit
-        ): ApiAuth = retrofit.create(ApiAuth::class.java)
+        ): ApiAuth = retrofit.create()
 
         @Provides
         @Singleton

--- a/opensource/src/main/java/ua/gov/diia/opensource/di/DocumentsModule.kt
+++ b/opensource/src/main/java/ua/gov/diia/opensource/di/DocumentsModule.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.plus
 import retrofit2.Retrofit
+import retrofit2.create
 import ua.gov.diia.core.di.data_source.http.AuthorizedClient
 import ua.gov.diia.core.util.date.CurrentDateProvider
 import ua.gov.diia.core.util.delegation.WithCrashlytics
@@ -137,7 +138,7 @@ interface DocumentsModule {
         @AuthorizedClient
         fun provideApiDocs(
             @AuthorizedClient retrofit: Retrofit,
-        ): ApiDocs = retrofit.create(ApiDocs::class.java)
+        ): ApiDocs = retrofit.create()
 
         @Provides
         @GlobalActionUpdateDocument

--- a/opensource/src/main/java/ua/gov/diia/opensource/di/NotificationPublicModule.kt
+++ b/opensource/src/main/java/ua/gov/diia/opensource/di/NotificationPublicModule.kt
@@ -5,6 +5,7 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import retrofit2.Retrofit
+import retrofit2.create
 import ua.gov.diia.core.data.data_source.network.api.notification.ApiNotificationsPublic
 import ua.gov.diia.core.di.data_source.http.AuthorizedClient
 import ua.gov.diia.core.di.data_source.http.UnauthorizedClient
@@ -17,11 +18,11 @@ object NotificationPublicModule {
     @AuthorizedClient
     fun provideApiNotificationPublicAuthorized(
         @AuthorizedClient retrofit: Retrofit
-    ): ApiNotificationsPublic = retrofit.create(ApiNotificationsPublic::class.java)
+    ): ApiNotificationsPublic = retrofit.create()
 
     @Provides
     @UnauthorizedClient
     fun provideApiNotificationPublicUnauthorized(
         @UnauthorizedClient retrofit: Retrofit
-    ): ApiNotificationsPublic = retrofit.create(ApiNotificationsPublic::class.java)
+    ): ApiNotificationsPublic = retrofit.create()
 }

--- a/opensource/src/main/java/ua/gov/diia/opensource/di/network/UnAuthorizedApiModule.kt
+++ b/opensource/src/main/java/ua/gov/diia/opensource/di/network/UnAuthorizedApiModule.kt
@@ -5,6 +5,7 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import retrofit2.Retrofit
+import retrofit2.create
 import ua.gov.diia.core.data.data_source.network.api.ApiSettings
 import ua.gov.diia.core.di.data_source.http.UnauthorizedClient
 
@@ -16,5 +17,5 @@ object UnAuthorizedApiModule {
     @UnauthorizedClient
     fun provideApiSettings(
         @UnauthorizedClient retrofit: Retrofit
-    ): ApiSettings = retrofit.create(ApiSettings::class.java)
+    ): ApiSettings = retrofit.create()
 }

--- a/ps_criminal_cert/src/main/java/ua/gov/diia/ps_criminal_cert/di/CriminalCertApiModule.kt
+++ b/ps_criminal_cert/src/main/java/ua/gov/diia/ps_criminal_cert/di/CriminalCertApiModule.kt
@@ -5,6 +5,7 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import retrofit2.Retrofit
+import retrofit2.create
 import ua.gov.diia.core.di.data_source.http.AuthorizedClient
 import ua.gov.diia.ps_criminal_cert.network.ApiCriminalCert
 
@@ -16,5 +17,5 @@ object CriminalCertApiModule {
     @AuthorizedClient
     fun provideApiCriminalCert(
         @AuthorizedClient retrofit: Retrofit
-    ): ApiCriminalCert = retrofit.create(ApiCriminalCert::class.java)
+    ): ApiCriminalCert = retrofit.create()
 }

--- a/publicservice/src/main/java/ua/gov/diia/publicservice/di/PublicServicesModule.kt
+++ b/publicservice/src/main/java/ua/gov/diia/publicservice/di/PublicServicesModule.kt
@@ -5,6 +5,7 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import retrofit2.Retrofit
+import retrofit2.create
 import ua.gov.diia.core.di.data_source.http.AuthorizedClient
 import ua.gov.diia.publicservice.network.ApiPublicServices
 
@@ -16,5 +17,5 @@ object PublicServicesModule {
     @AuthorizedClient
     fun provideApiPublicServices(
         @AuthorizedClient retrofit: Retrofit
-    ): ApiPublicServices = retrofit.create(ApiPublicServices::class.java)
+    ): ApiPublicServices = retrofit.create()
 }

--- a/verification/src/main/java/ua/gov/diia/verification/di/VerificationModule.kt
+++ b/verification/src/main/java/ua/gov/diia/verification/di/VerificationModule.kt
@@ -6,6 +6,7 @@ import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import kotlinx.coroutines.runBlocking
 import retrofit2.Retrofit
+import retrofit2.create
 import ua.gov.diia.core.di.data_source.http.AuthorizedClient
 import ua.gov.diia.core.di.data_source.http.ProlongClient
 import ua.gov.diia.core.di.data_source.http.UnauthorizedClient
@@ -22,19 +23,19 @@ object VerificationModule {
     @AuthorizedClient
     fun provideApiVerificationAuthorized(
         @AuthorizedClient retrofit: Retrofit
-    ): ApiVerification = retrofit.create(ApiVerification::class.java)
+    ): ApiVerification = retrofit.create()
 
     @Provides
     @UnauthorizedClient
     fun provideApiVerificationUnauthorized(
         @UnauthorizedClient retrofit: Retrofit
-    ): ApiVerification = retrofit.create(ApiVerification::class.java)
+    ): ApiVerification = retrofit.create()
 
     @Provides
     @ProlongClient
     fun provideApiVerificationProlong(
         @ProlongClient retrofit: Retrofit
-    ): ApiVerification = retrofit.create(ApiVerification::class.java)
+    ): ApiVerification = retrofit.create()
 
     @Provides
     @ProviderVerifiedClient


### PR DESCRIPTION
A minor code improvement. It is not necessary to pass java class when using Kotlin. The more elegant way is to use `Retrofit.create()` extension from the retrofit library