### PR TITLE
Huwai, Jcenter, Jitpack dependency repos clean up to reduce supply-chain attack surface

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,10 +3,11 @@
 buildscript {
     repositories {
         google()
-        jcenter()
         mavenCentral()
-        maven { url 'https://jitpack.io' }
-        maven { url 'https://developer.huawei.com/repo/' }
+        maven {
+            url 'https://developer.huawei.com/repo/'
+            content { includeGroupByRegex "com.huawei.*" }
+        }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:7.3.1'
@@ -30,12 +31,15 @@ plugins {
 allprojects {
     repositories {
         google()
-        jcenter()
         mavenCentral()
         maven {
             url 'https://jitpack.io'
+            content { includeGroupByRegex "com.github.AbedElazizShe:*" }
         }
-        maven { url 'https://developer.huawei.com/repo/' }
+        maven {
+            url 'https://developer.huawei.com/repo/'
+            content { includeGroupByRegex "com.huawei.*" }
+        }
     }
 }
 

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -91,7 +91,7 @@ ext {
             //ui
             lottie                                   : 'com.airbnb.android:lottie:6.2.0',
             lottie_compose                           : 'com.airbnb.android:lottie-compose:6.1.0',
-            flexbox                                  : 'com.google.android:flexbox:2.0.1',
+            flexbox                                  : 'com.google.android.flexbox:flexbox:3.0.0',
             shortcut_badger                          : "me.leolin:ShortcutBadger:1.1.22@aar",
             better_link_movement_method              : 'me.saket:better-link-movement-method:2.2.0',
             browser                                  : "androidx.browser:browser:1.3.0",

--- a/opensource/build.gradle
+++ b/opensource/build.gradle
@@ -6,7 +6,6 @@ apply plugin: 'androidx.navigation.safeargs.kotlin'
 apply plugin: 'dagger.hilt.android.plugin'
 apply plugin: 'com.google.gms.google-services'
 apply plugin: 'com.google.firebase.crashlytics'
-apply plugin: 'com.huawei.agconnect'
 
 apply from: '../dependencies.gradle'
 
@@ -66,6 +65,7 @@ android {
 
         huawei {
             dimension "vendor"
+            apply plugin: 'com.huawei.agconnect'
         }
     }
 


### PR DESCRIPTION
In this PR:
- Applying `com.huawei.agconnect` plugin in `huawei `flavor only. Also limiting Huawei repo to fetch only Huawei related libraries.
Huawei plugin is **not open-source**, **hosted on a private repo** (https://developer.huawei.com/repo) and **developed by a Chinese company with a known history of cyberspy allegations** (https://en.wikipedia.org/wiki/Criticism_of_Huawei). 
**This is an ideal recipe for a supply-chain attack** where in one of routine CI builds a modified `agconnect` plugin can be automatically downloaded, inject code into the build which will be distributed with the apk release. 

- Dropped Jcenter repo for buildScript and project itself . The only dependency hosted there (https://github.com/google/flexbox-layout/releases) has been moved to `mavenCentral`. Version increase brought only package name change according to their github page.  Jcenter was also compromised in 2018 supply chain attack (https://web.archive.org/web/20181214053140/http://blog.autsoft.hu/a-confusing-dependency/)
- Dropped Jitpack repo for buildScript . Project repo scope reduced to the only library hosted there (https://github.com/AbedElazizShe/LightCompressor).
- This should also benefit build times a little due to reduce index of repos and one less build plugins for `gplay` flavor.
