### PR TITLE
Build Failure fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,6 @@
 buildscript {
     repositories {
         google()
-        jcenter()
         mavenCentral()
         maven { url 'https://jitpack.io' }
         maven { url 'https://developer.huawei.com/repo/' }
@@ -30,12 +29,12 @@ plugins {
 allprojects {
     repositories {
         google()
-        jcenter()
         mavenCentral()
         maven {
             url 'https://jitpack.io'
         }
         maven { url 'https://developer.huawei.com/repo/' }
+        maven { url "https://maven.aliyun.com/repository/jcenter" }
     }
 }
 


### PR DESCRIPTION
When attempting to build the latest version of the repository, I encounter an error:

![image](https://github.com/user-attachments/assets/cdffc554-1f10-4bc6-b529-44e1d560b72e)

I have fixed this error. 
Here are some useful references:
https://stackoverflow.com/questions/76536190/android-build-failure-could-not-find-flexbox-2-0-1-aar