### PR TITLE
Fragment Result Bug

### DIFF
--- a/core/src/main/java/ua/gov/diia/core/util/extensions/fragment/FragmentResultExt.kt
+++ b/core/src/main/java/ua/gov/diia/core/util/extensions/fragment/FragmentResultExt.kt
@@ -1,7 +1,10 @@
 package ua.gov.diia.core.util.extensions.fragment
 
 import androidx.annotation.IdRes
+import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.setFragmentResult
+import androidx.fragment.app.setFragmentResultListener
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.SavedStateHandle
@@ -66,8 +69,9 @@ inline fun Fragment.registerForTemplateDialogNavResult(
     key: String = ActionsConst.FRAGMENT_USER_ACTION_RESULT_KEY,
     crossinline resultEvent: (String) -> Unit
 ) {
-    registerForNavigationResult<ConsumableString>(key) { event ->
-        event.consumeEvent { action -> resultEvent.invoke(action) }
+    setFragmentResultListener(key) { _, bundle ->
+        val event = bundle.getParcelable<ConsumableString>(key)
+        event?.consumeEvent { action -> resultEvent.invoke(action) }
     }
 }
 
@@ -113,7 +117,7 @@ fun <T : Any> Fragment.setNavigationResult(
     key: String,
     navController: NavController = findNavController()
 ) {
-    navController.previousBackStackEntry?.savedStateHandle?.set(key, result)
+    setFragmentResult(key, bundleOf(key to  result))
 }
 
 /**


### PR DESCRIPTION
Когда показывается диалоговое окно об успешной авторизации, и в этот момент изменяется конфигурация устройства, кнопка "Продолжить" становится некликабельной.

https://github.com/user-attachments/assets/0288528f-2fb3-4906-a767-e5e95a34a018

Что происходит в приложении:

У нас есть такой стек: `LoginF` -> `TemplateDialogF`. Когда мы находимся в `LoginF `(VerificationControllerOnFlowF), мы регистрируем колбек на результат в функции `registerForTemplateDialogNavResult`, которая берет `currentBackStackEntry` как текущий элемент в стеке. Затем мы переходим на `TemplateDialogF`. На этом этапе все работает хорошо. Однако при смене конфигурации `LoginF `снова регистрирует колбек, но на этот раз `currentBackStackEntry` — это наш `TemplateDialogF`, так как он является последним в стеке. После этого, когда мы нажимаем кнопку "Назад", результат передается в `previousBackStackEntry`, но безуспешно ведь новый колбек зарегистрирован в `currentBackStackEntry`, то есть в `TemplateDialogF`, поскольку колбек был перерегистрирован при смене конфигурации. Таким образом, наш предыдущий фрагмент не сможет получить результат.

Чтобы решить этот конфликт, нужно обеспечить, чтобы колбек не регистрировался заново. Однако для реализации этого решения пришлось бы писать костыли, чего делать не хотелось бы. По крайней мере, мне в голову приходят только такие решения. Вместо этого я решил заменить кастомную реализацию на стандартную, а именно использовать `setFragmentResultListener` и `setFragmentResult`, которые работают довольно хорошо. Таким образом, удалось пофиксить баг.